### PR TITLE
Change default schema to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ git_now:
   # source dir (default: #{node[:git_now][:prefix]}/src)
   src: /usr/local/src
   
-  # specify scheme to use in git clone (default: git)
-  scheme: git
+  # specify scheme to use in git clone (default: https)
+  scheme: https
 
   # install revision (default: HEAD)
   revision: v0.1.1.0

--- a/lib/itamae/plugin/recipe/git_now/default.rb
+++ b/lib/itamae/plugin/recipe/git_now/default.rb
@@ -1,7 +1,7 @@
 node.reverse_merge!(
   git_now: {
     prefix: "/usr/local",
-    scheme: "git",
+    scheme: "https",
   },
 )
 

--- a/spec/recipes/install.rb
+++ b/spec/recipes/install.rb
@@ -1,6 +1,13 @@
 case node[:platform]
 when "debian", "ubuntu"
   execute "apt-get update"
+
+when "redhat"
+  if node[:platform_version].to_f >= 8.0
+    # FIXME: Workaround for following
+    # Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
+    execute "sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\\/\\/mirror/baseurl=http:\\/\\/vault/g' /etc/yum.repos.d/CentOS-*repo"
+  end
 end
 
 include_recipe "git_now"


### PR DESCRIPTION
https://github.com/sue445/itamae-plugin-recipe-git_now/runs/5690115077?check_suite_focus=true

```
 INFO :     git[/usr/local/src/git-now] exist will change from 'false' to 'true'
ERROR :       stderr | Cloning into '/usr/local/src/git-now'...
ERROR :       stderr | fatal: remote error:
ERROR :       stderr |   The unauthenticated git protocol on port 9418 is no longer supported.
ERROR :       stderr | Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
ERROR :       Command `git clone --recursive git://github.com/iwata/git-now.git /usr/local/src/git-now` failed. (exit status: 128)
```