### PR TITLE
Drop support Jessie

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
         image:
           - centos:7
           - centos:8
-          - debian:jessie
           - debian:stretch
           - debian:buster
 


### PR DESCRIPTION
Jessie is already EOL
https://wiki.debian.org/LTS

Close #29